### PR TITLE
feat(cf-eventhub): implement fast-path

### DIFF
--- a/.changeset/lovely-results-camp.md
+++ b/.changeset/lovely-results-camp.md
@@ -1,0 +1,5 @@
+---
+"cf-eventhub": minor
+---
+
+implement fast-path

--- a/.changeset/tidy-poems-guess.md
+++ b/.changeset/tidy-poems-guess.md
@@ -1,0 +1,5 @@
+---
+"cf-eventhub": patch
+---
+
+fix test

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ sequenceDiagram
   end
 ```
 
+### Fast path
+
+Set `EVENTHUB_FAST_PATH_URL` and `EVENTHUB_FAST_PATH_SECRET` on both eventhub
+and executor workers to start zero-delay dispatches via signed HTTP before the
+Queue consumer receives them. Queue messages are still enqueued as fallback.
+
+- The eventhub sends `POST /__cf_eventhub/fast-path` with an HMAC-SHA256
+  signature.
+- The executor verifies the signature and calls the same dispatcher used by the
+  Queue consumer.
+- Only dispatches with `delaySeconds: 0` use the fast path.
+- If the fast path fails, the Queue message is retried using the configured
+  retry delay.
+
 ## To run demo
 1. Launch demo workers
     ```shell

--- a/biome.json
+++ b/biome.json
@@ -23,5 +23,23 @@
         "useShorthandFunctionType": "off"
       }
     }
+  },
+  "javascript": {
+    "globals": [
+      "Queue",
+      "MessageSendRequest",
+      "Message",
+      "MessageBatch",
+      "QueueSendOptions",
+      "QueueSendBatchOptions",
+      "ExecutionContext",
+      "ScheduledController",
+      "Service",
+      "Rpc",
+      "HtmxAttributes",
+      "Hyperdrive",
+      "R2Bucket",
+      "R2Object"
+    ]
   }
 }

--- a/cf-eventhub/src/core/executor/dispatcher.worker.test.ts
+++ b/cf-eventhub/src/core/executor/dispatcher.worker.test.ts
@@ -23,6 +23,12 @@ const Payload = v.object({
 });
 
 describe("dispatch", () => {
+  const defaultRetryDelay = { type: "exponential", base: 2, max: 20 } as const;
+  const createMessage = (dispatchId: string) => ({
+    dispatchId,
+    retryDelay: defaultRetryDelay,
+  });
+
   const createDispatch = async (
     repo: Repository,
     destination: string,
@@ -71,11 +77,11 @@ describe("dispatch", () => {
     });
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage(dispatchId));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "complete",
     });
-    expect(result).toBe("complete");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>
@@ -90,11 +96,11 @@ describe("dispatch", () => {
     const d = new Dispatcher(repo, env, new DefaultLogger("ERROR"));
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId: "not_found_dispatch",
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage("not_found_dispatch"));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "notfound",
     });
-    expect(result).toBe("notfound");
   });
 
   test("resulted dispatch causes dispatch 'notfound'", async () => {
@@ -118,11 +124,11 @@ describe("dispatch", () => {
     assert(createResult.isOk());
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage(dispatchId));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "notfound",
     });
-    expect(result).toBe("notfound");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>
@@ -141,11 +147,11 @@ describe("dispatch", () => {
     });
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage(dispatchId));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "failed",
     });
-    expect(result).toBe("failed");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>
@@ -162,27 +168,40 @@ describe("dispatch", () => {
     const dispatchId = await createDispatch(repo, "HANDLER", {
       expectedResult: "failed",
     });
+    const retryDelay = { type: "constant", interval: 1 } as const;
+    const msg = {
+      dispatchId,
+      retryDelay,
+    };
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const firstAttempt = await d.attemptDispatch(msg);
+    expect(firstAttempt).toMatchObject({
+      type: "dispatched",
+      result: "failed",
     });
-    expect(result).toBe("failed");
 
     // First retry.
-    const firstRetryResult = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const firstRetryResult = await d.attemptDispatch(
+      msg,
+      0,
+      new Date(Date.now() + 1_100),
+    );
+    expect(firstRetryResult).toMatchObject({
+      type: "dispatched",
+      result: "failed",
     });
-    expect(firstRetryResult).toBe("failed");
 
-    // Last retry.
-    const lastRetry = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    // Second retry.
+    const secondRetryResult = await d.attemptDispatch(
+      msg,
+      0,
+      new Date(Date.now() + 2_200),
+    );
+    expect(secondRetryResult).toMatchObject({
+      type: "dispatched",
+      result: "failed",
     });
-    expect(lastRetry).toBe("failed");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>
@@ -191,12 +210,16 @@ describe("dispatch", () => {
     assert(dispatch.isOk());
     expect(dispatch.value?.dispatch.status).toBe("failed");
 
-    // Extra retry.
-    const extraResult = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    // Retry after resulted dispatch.
+    const afterExhaustedResult = await d.attemptDispatch(
+      msg,
+      0,
+      new Date(Date.now() + 3_300),
+    );
+    expect(afterExhaustedResult).toMatchObject({
+      type: "dispatched",
+      result: "notfound",
     });
-    expect(extraResult).toBe("notfound");
   });
 
   test("not found destination makes dispatch 'misconfigured'", async () => {
@@ -208,11 +231,11 @@ describe("dispatch", () => {
     });
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage(dispatchId));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "misconfigured",
     });
-    expect(result).toBe("misconfigured");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>
@@ -247,11 +270,11 @@ describe("dispatch", () => {
     });
 
     // Execute and check result.
-    const result = await d.dispatch({
-      dispatchId,
-      retryDelay: { type: "exponential", base: 2, max: 20 },
+    const result = await d.attemptDispatch(createMessage(dispatchId));
+    expect(result).toMatchObject({
+      type: "dispatched",
+      result: "complete",
     });
-    expect(result).toBe("complete");
 
     // Check dispatch status.
     const dispatch = await repo.mutate((tx) =>

--- a/cf-eventhub/src/core/executor/index.ts
+++ b/cf-eventhub/src/core/executor/index.ts
@@ -4,6 +4,7 @@ import { formatException } from "../../utils/format-exception";
 import type { Logger } from "../logger";
 import { type DispatchExecution, appendExecutionLog } from "../model";
 import type { Repository } from "../repository";
+import { nextDelay } from "../retry-delay";
 import type { QueueMessage } from "../type";
 import {
   type Handler,
@@ -25,6 +26,64 @@ export class Dispatcher {
       return null;
     }
     return isHandler(dest) ? dest : isR2Bucket(dest) ? dest : null;
+  }
+
+  /**
+   * Returns remaining delay seconds when Queue fallback should be postponed.
+   *
+   * This is used to keep the Queue consumer aligned with the retry schedule
+   * after the same dispatch was already attempted via fast path.
+   */
+  async getPostponedRetryDelaySeconds(
+    msg: QueueMessage,
+    queueAttempts = 0,
+    now = new Date(),
+  ): Promise<number | undefined> {
+    const result = await this.repo.mutate(async (tx) => {
+      const dispatchResult = await tx.getTargetDispatch(msg.dispatchId);
+      if (dispatchResult.isErr()) {
+        return ok(undefined);
+      }
+      if (
+        dispatchResult.value === null ||
+        dispatchResult.value.dispatch.status !== "ongoing"
+      ) {
+        return ok(undefined);
+      }
+
+      const { dispatch } = dispatchResult.value;
+      // Fast path executes the same dispatch before the queued message arrives.
+      // If the fast path already failed and the next retry window has not opened
+      // yet, consuming the queued message immediately would start the retry too
+      // early. In that case, tell the caller to re-delay the queued message so
+      // that Queue fallback follows the same retry schedule.
+      //
+      // `queueAttempts` is used only for Queue consumers. Fast path requests do
+      // not increment Queue attempts, so a queued message should not be delayed
+      // unless the dispatch already has at least the same number of executions.
+      if (dispatch.executionLog.length < queueAttempts) {
+        return ok(undefined);
+      }
+
+      const lastExecution =
+        dispatch.executionLog[dispatch.executionLog.length - 1];
+      if (!lastExecution || lastExecution.result !== "failed") {
+        return ok(undefined);
+      }
+
+      const delaySeconds = nextDelay({
+        retryDelay: msg.retryDelay,
+        attempts: dispatch.executionLog.length,
+      });
+      if (!delaySeconds) {
+        return ok(undefined);
+      }
+
+      const dueAt = lastExecution.executedAt.getTime() + delaySeconds * 1000;
+      const remainingSeconds = Math.ceil((dueAt - now.getTime()) / 1000);
+      return ok(remainingSeconds > 0 ? remainingSeconds : undefined);
+    });
+    return result.unwrapOr(undefined);
   }
 
   async dispatch(msg: QueueMessage): Promise<DispatchExecution["result"]> {

--- a/cf-eventhub/src/core/executor/index.ts
+++ b/cf-eventhub/src/core/executor/index.ts
@@ -1,17 +1,29 @@
-import { fromAsyncThrowable, ok } from "neverthrow";
+import { ok } from "neverthrow";
 
 import { formatException } from "../../utils/format-exception";
 import type { Logger } from "../logger";
-import { type DispatchExecution, appendExecutionLog } from "../model";
-import type { Repository } from "../repository";
+import {
+  type CreatedEvent,
+  type DispatchExecution,
+  type OngoingDispatch,
+  appendExecutionLog,
+} from "../model";
+import type { MutationRepository, Repository } from "../repository";
 import { nextDelay } from "../retry-delay";
-import type { QueueMessage } from "../type";
+import type { EventPayload, QueueMessage } from "../type";
 import {
   type Handler,
   isHandler,
   isR2Bucket,
   validHandlerResult,
 } from "./handler";
+
+export type DispatchAttemptResult =
+  | { type: "postponed"; delaySeconds: number }
+  | {
+      type: "dispatched";
+      result: DispatchExecution["result"];
+    };
 
 export class Dispatcher {
   constructor(
@@ -29,129 +41,166 @@ export class Dispatcher {
   }
 
   /**
-   * Returns remaining delay seconds when Queue fallback should be postponed.
+   * Runs dispatch execution under a single transactional lock.
    *
-   * This is used to keep the Queue consumer aligned with the retry schedule
-   * after the same dispatch was already attempted via fast path.
+   * When the same dispatch was already attempted via fast path, Queue fallback
+   * may need to wait until the retry window opens. In that case this returns
+   * `postponed` instead of starting the handler execution immediately.
    */
-  async getPostponedRetryDelaySeconds(
+  async attemptDispatch(
     msg: QueueMessage,
     queueAttempts = 0,
     now = new Date(),
-  ): Promise<number | undefined> {
-    const result = await this.repo.mutate(async (tx) => {
-      const dispatchResult = await tx.getTargetDispatch(msg.dispatchId);
-      if (dispatchResult.isErr()) {
-        return ok(undefined);
-      }
-      if (
-        dispatchResult.value === null ||
-        dispatchResult.value.dispatch.status !== "ongoing"
-      ) {
-        return ok(undefined);
-      }
+  ): Promise<DispatchAttemptResult> {
+    const result = await this.repo.mutate<DispatchAttemptResult, never>(
+      async (tx) => {
+        const dispatchResult = await tx.getTargetDispatch(msg.dispatchId);
+        if (dispatchResult.isErr()) {
+          return ok({
+            type: "dispatched" as const,
+            result: "failed" as const,
+          });
+        }
+        if (
+          dispatchResult.value === null ||
+          dispatchResult.value.dispatch.status !== "ongoing"
+        ) {
+          return ok({
+            type: "dispatched" as const,
+            result: "notfound" as const,
+          });
+        }
 
-      const { dispatch } = dispatchResult.value;
-      // Fast path executes the same dispatch before the queued message arrives.
-      // If the fast path already failed and the next retry window has not opened
-      // yet, consuming the queued message immediately would start the retry too
-      // early. In that case, tell the caller to re-delay the queued message so
-      // that Queue fallback follows the same retry schedule.
-      //
-      // `queueAttempts` is used only for Queue consumers. Fast path requests do
-      // not increment Queue attempts, so a queued message should not be delayed
-      // unless the dispatch already has at least the same number of executions.
-      if (dispatch.executionLog.length < queueAttempts) {
-        return ok(undefined);
-      }
+        const { dispatch } = dispatchResult.value;
+        // Fast path executes the same dispatch before the queued message arrives.
+        // If the fast path already failed and the next retry window has not opened
+        // yet, consuming the queued message immediately would start the retry too
+        // early. In that case, tell the caller to re-delay the queued message so
+        // that Queue fallback follows the same retry schedule.
+        //
+        // `queueAttempts` is used only for Queue consumers. Fast path requests do
+        // not increment Queue attempts, so a queued message should not be delayed
+        // unless the dispatch already has at least the same number of executions.
+        if (dispatch.executionLog.length < queueAttempts) {
+          return this.dispatchInTransaction(
+            dispatchResult.value.event,
+            dispatch,
+            tx,
+          );
+        }
+        const postponedDelaySeconds = this.getPostponedRetryDelaySeconds(
+          dispatch,
+          msg,
+          now,
+        );
+        if (postponedDelaySeconds) {
+          return ok({
+            type: "postponed" as const,
+            delaySeconds: postponedDelaySeconds,
+          });
+        }
 
-      const lastExecution =
-        dispatch.executionLog[dispatch.executionLog.length - 1];
-      if (!lastExecution || lastExecution.result !== "failed") {
-        return ok(undefined);
-      }
-
-      const delaySeconds = nextDelay({
-        retryDelay: msg.retryDelay,
-        attempts: dispatch.executionLog.length,
-      });
-      if (!delaySeconds) {
-        return ok(undefined);
-      }
-
-      const dueAt = lastExecution.executedAt.getTime() + delaySeconds * 1000;
-      const remainingSeconds = Math.ceil((dueAt - now.getTime()) / 1000);
-      return ok(remainingSeconds > 0 ? remainingSeconds : undefined);
-    });
-    return result.unwrapOr(undefined);
+        return this.dispatchInTransaction(
+          dispatchResult.value.event,
+          dispatch,
+          tx,
+        );
+      },
+    );
+    return result.match(
+      (attempt) => attempt,
+      (e) => {
+        this.logger.error("error on dispatch", { error: formatException(e) });
+        return {
+          type: "dispatched",
+          result: "failed",
+        };
+      },
+    );
   }
 
   async dispatch(msg: QueueMessage): Promise<DispatchExecution["result"]> {
-    const result = await this.repo.mutate(async (tx) => {
-      const dispatchResult = await tx.getTargetDispatch(msg.dispatchId);
-      if (dispatchResult.isErr()) {
-        return ok("failed" as const);
-      }
+    const result = await this.attemptDispatch(msg);
+    return result.type === "dispatched" ? result.result : "failed";
+  }
 
-      if (
-        dispatchResult.value === null ||
-        dispatchResult.value.dispatch.status !== "ongoing"
-      ) {
-        return ok("notfound" as const);
-      }
-      const { event, dispatch } = dispatchResult.value;
+  private getPostponedRetryDelaySeconds(
+    dispatch: {
+      executionLog: readonly {
+        result: string;
+        executedAt: Date;
+      }[];
+    },
+    msg: QueueMessage,
+    now: Date,
+  ): number | undefined {
+    const lastExecution =
+      dispatch.executionLog[dispatch.executionLog.length - 1];
+    if (!lastExecution || lastExecution.result !== "failed") {
+      return undefined;
+    }
 
-      const result = await fromAsyncThrowable(
-        async () => {
-          const handler = this.findDestinationHandler(dispatch.destination);
-          if (!handler) {
-            this.logger.error(`handler not found: ${dispatch.destination}`);
-            return "misconfigured" as const;
-          }
+    const delaySeconds = nextDelay({
+      retryDelay: msg.retryDelay,
+      attempts: dispatch.executionLog.length,
+    });
+    if (!delaySeconds) {
+      return undefined;
+    }
 
-          // call handler
-          if (isHandler(handler)) {
-            const result = await handler.handle(event.payload);
-            if (!validHandlerResult(result)) {
-              this.logger.error(
-                `got invalid result from handler ${dispatch.destination}: ${result}`,
-              );
-              return "failed" as const;
-            }
-            return result;
-          }
+    const dueAt = lastExecution.executedAt.getTime() + delaySeconds * 1000;
+    const remainingSeconds = Math.ceil((dueAt - now.getTime()) / 1000);
+    return remainingSeconds > 0 ? remainingSeconds : undefined;
+  }
 
-          // or put to R2 bucket directly
-          const objectKey = `${new Date().toISOString()}-${dispatch.id}`;
-          await handler.put(objectKey, JSON.stringify(event.payload));
-          return "complete" as const;
-        },
-        (e) => {
-          this.logger.error(`handler ${dispatch.destination} rejected`, {
-            error: formatException(e),
-          });
-          return "failed" as const;
-        },
-      )().unwrapOr("failed" as const); // impossible path
-
-      // Save execution result.
+  private async dispatchInTransaction(
+    event: CreatedEvent,
+    dispatch: OngoingDispatch,
+    tx: MutationRepository,
+  ) {
+    return this.runHandler(event, dispatch).then(async (result) => {
       const appendedDispatch = appendExecutionLog(dispatch, {
         result,
         executedAt: new Date(),
       });
       const saveResult = await tx.saveDispatch(appendedDispatch);
-      if (saveResult.isErr()) {
-        return ok("failed" as const);
+      return ok({
+        type: "dispatched" as const,
+        result: saveResult.isErr() ? ("failed" as const) : result,
+      });
+    });
+  }
+
+  private async runHandler(
+    event: CreatedEvent,
+    dispatch: OngoingDispatch,
+  ): Promise<DispatchExecution["result"]> {
+    try {
+      const handler = this.findDestinationHandler(dispatch.destination);
+      if (!handler) {
+        this.logger.error(`handler not found: ${dispatch.destination}`);
+        return "misconfigured" as const;
       }
 
-      return ok(result);
-    });
-    return result.match(
-      (result) => result,
-      (e) => {
-        this.logger.error("error on dispatch", { error: formatException(e) });
-        return "failed";
-      },
-    );
+      if (isHandler(handler)) {
+        const result = await handler.handle(event.payload as EventPayload);
+        if (!validHandlerResult(result)) {
+          this.logger.error(
+            `got invalid result from handler ${dispatch.destination}: ${result}`,
+          );
+          return "failed" as const;
+        }
+        return result;
+      }
+
+      const objectKey = `${new Date().toISOString()}-${dispatch.id}`;
+      await handler.put(objectKey, JSON.stringify(event.payload));
+      return "complete" as const;
+    } catch (e) {
+      this.logger.error(`handler ${dispatch.destination} rejected`, {
+        error: formatException(e),
+      });
+      return "failed" as const;
+    }
   }
 }

--- a/cf-eventhub/src/core/executor/index.ts
+++ b/cf-eventhub/src/core/executor/index.ts
@@ -119,6 +119,9 @@ export class Dispatcher {
     );
   }
 
+  /**
+   * @deprecated Use `attemptDispatch()` to preserve postponed retry semantics.
+   */
   async dispatch(msg: QueueMessage): Promise<DispatchExecution["result"]> {
     const result = await this.attemptDispatch(msg);
     return result.type === "dispatched" ? result.result : "failed";

--- a/cf-eventhub/src/core/fast-path.ts
+++ b/cf-eventhub/src/core/fast-path.ts
@@ -131,10 +131,5 @@ export const parseFastPathRequest = async (
     return null;
   }
 
-  try {
-    return v.parse(FastPathPayload, JSON.parse(body));
-  } catch (e) {
-    console.error("invalid fast path payload", formatException(e));
-    return null;
-  }
+  return v.parse(FastPathPayload, JSON.parse(body));
 };

--- a/cf-eventhub/src/core/fast-path.ts
+++ b/cf-eventhub/src/core/fast-path.ts
@@ -1,0 +1,140 @@
+import * as v from "valibot";
+
+import { formatException } from "../utils/format-exception";
+import type { Logger } from "./logger";
+import type { QueueMessage } from "./type";
+
+export const FAST_PATH_PATH = "/__cf_eventhub/fast-path";
+
+const SIGNATURE_HEADER = "x-cf-eventhub-signature";
+const TIMESTAMP_HEADER = "x-cf-eventhub-timestamp";
+const SIGNATURE_VERSION = "v1";
+const DEFAULT_TOLERANCE_SECONDS = 300;
+
+const FastPathPayload = v.object({
+  dispatches: v.array(
+    v.object({
+      dispatchId: v.pipe(v.string(), v.minLength(1)),
+      retryDelay: v.variant("type", [
+        v.object({
+          type: v.literal("constant"),
+          interval: v.number(),
+        }),
+        v.object({
+          type: v.literal("exponential"),
+          base: v.number(),
+          max: v.number(),
+        }),
+      ]),
+    }),
+  ),
+});
+
+export type FastPathPayload = v.InferOutput<typeof FastPathPayload>;
+
+const encoder = new TextEncoder();
+
+const bytesToHex = (bytes: ArrayBuffer) =>
+  [...new Uint8Array(bytes)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+const timingSafeEqual = (a: string, b: string) => {
+  const aBytes = encoder.encode(a.toLowerCase());
+  const bBytes = encoder.encode(b.toLowerCase());
+  const lengthsMatch = aBytes.byteLength === bBytes.byteLength;
+  return lengthsMatch
+    ? crypto.subtle.timingSafeEqual(aBytes, bBytes)
+    : !crypto.subtle.timingSafeEqual(aBytes, aBytes);
+};
+
+const importKey = (secret: string) =>
+  crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+const sign = async (secret: string, timestamp: string, body: string) => {
+  const key = await importKey(secret);
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${body}`),
+  );
+  return bytesToHex(signature);
+};
+
+export class FastPathClient {
+  constructor(
+    private readonly url: string,
+    private readonly secret: string,
+    private readonly logger: Logger,
+  ) {}
+
+  async dispatch(messages: QueueMessage[]): Promise<void> {
+    if (messages.length === 0) {
+      return;
+    }
+
+    const body = JSON.stringify({ dispatches: messages });
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await sign(this.secret, timestamp, body);
+    const response = await fetch(this.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        [TIMESTAMP_HEADER]: timestamp,
+        [SIGNATURE_HEADER]: `${SIGNATURE_VERSION}=${signature}`,
+      },
+      body,
+    });
+    if (!response.ok) {
+      this.logger.error("fast path request failed", {
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+  }
+}
+
+export const parseFastPathRequest = async (
+  request: Request,
+  secret: string,
+  now = new Date(),
+  toleranceSeconds = DEFAULT_TOLERANCE_SECONDS,
+): Promise<FastPathPayload | null> => {
+  if (request.method !== "POST") {
+    return null;
+  }
+
+  const timestamp = request.headers.get(TIMESTAMP_HEADER);
+  const signature = request.headers.get(SIGNATURE_HEADER);
+  if (!timestamp || !signature?.startsWith(`${SIGNATURE_VERSION}=`)) {
+    return null;
+  }
+
+  const timestampSeconds = Number.parseInt(timestamp);
+  if (
+    !Number.isSafeInteger(timestampSeconds) ||
+    Math.abs(now.getTime() / 1000 - timestampSeconds) > toleranceSeconds
+  ) {
+    return null;
+  }
+
+  const body = await request.text();
+  const expected = await sign(secret, timestamp, body);
+  const actual = signature.slice(`${SIGNATURE_VERSION}=`.length);
+  if (!timingSafeEqual(expected, actual)) {
+    return null;
+  }
+
+  try {
+    return v.parse(FastPathPayload, JSON.parse(body));
+  } catch (e) {
+    console.error("invalid fast path payload", formatException(e));
+    return null;
+  }
+};

--- a/cf-eventhub/src/core/fast-path.worker.test.ts
+++ b/cf-eventhub/src/core/fast-path.worker.test.ts
@@ -1,0 +1,70 @@
+import { assert, describe, expect, test, vi } from "vitest";
+
+import {
+  FastPathClient,
+  type FastPathPayload,
+  parseFastPathRequest,
+} from "./fast-path";
+import { DefaultLogger } from "./logger";
+
+describe("fast path signing", () => {
+  test("FastPathClient sends verifiable HMAC request", async () => {
+    const secret = "test-secret";
+    const payloads: FastPathPayload[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init);
+        const payload = await parseFastPathRequest(request, secret);
+        assert(payload);
+        payloads.push(payload);
+        return Response.json({ ok: true });
+      },
+    );
+
+    try {
+      const client = new FastPathClient(
+        "https://executor.example/__cf_eventhub/fast-path",
+        secret,
+        new DefaultLogger("ERROR"),
+      );
+      await client.dispatch([
+        {
+          dispatchId: "dispatch-id",
+          retryDelay: { type: "constant", interval: 5 },
+        },
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(payloads).toEqual([
+      {
+        dispatches: [
+          {
+            dispatchId: "dispatch-id",
+            retryDelay: { type: "constant", interval: 5 },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("parseFastPathRequest rejects invalid signature", async () => {
+    const request = new Request(
+      "https://executor.example/__cf_eventhub/fast-path",
+      {
+        method: "POST",
+        headers: {
+          "x-cf-eventhub-timestamp": Math.floor(Date.now() / 1000).toString(),
+          "x-cf-eventhub-signature": "v1=deadbeef",
+        },
+        body: JSON.stringify({ dispatches: [] }),
+      },
+    );
+
+    await expect(parseFastPathRequest(request, "test-secret")).resolves.toBe(
+      null,
+    );
+  });
+});

--- a/cf-eventhub/src/core/hub/hub.worker.test.ts
+++ b/cf-eventhub/src/core/hub/hub.worker.test.ts
@@ -1,7 +1,8 @@
-import { assert, describe, expect, test } from "vitest";
+import { assert, describe, expect, test, vi } from "vitest";
 
 import { EventSink } from ".";
 import { DevRepository } from "../../dev/repository";
+import { FAST_PATH_PATH, parseFastPathRequest } from "../fast-path";
 import { DefaultLogger } from "../logger";
 import { appendExecutionLog, makeDispatchLost } from "../model";
 import type { Repository } from "../repository";
@@ -234,6 +235,77 @@ describe("putEvent", () => {
 
     // Check sent messages.
     expect(queue.sentMessages).toHaveLength(0);
+  });
+
+  test("putEvent dispatches zero-delay messages via fast path", async () => {
+    const repo = new DevRepository();
+    const secret = "test-secret";
+    const fastRoute: Config = {
+      defaultDelaySeconds: 0,
+      defaultMaxRetries: 5,
+      defaultRetryDelay: { type: "constant", interval: 7 },
+      routes: [
+        {
+          condition: { path: "$.kind", exact: "fast" },
+          destination: "FAST",
+        },
+        {
+          condition: { path: "$.kind", exact: "slow" },
+          destination: "SLOW",
+          delaySeconds: 3,
+        },
+      ],
+    };
+    const queue = new QueueMock();
+    const fastPathPayloads: QueueMessage[][] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init);
+        expect(new URL(request.url).pathname).toBe(FAST_PATH_PATH);
+        const payload = await parseFastPathRequest(request, secret);
+        assert(payload);
+        fastPathPayloads.push(payload.dispatches);
+        return Response.json({ ok: true });
+      },
+    );
+
+    try {
+      const sink = new EventSink(
+        repo,
+        queue,
+        fastRoute,
+        new DefaultLogger("ERROR"),
+        {
+          url: `https://executor.example${FAST_PATH_PATH}`,
+          secret,
+        },
+      );
+      await sink.putEvent([{ kind: "fast" }, { kind: "slow" }]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const dispatches = await repo.readDispatches(100);
+    assert(dispatches.isOk());
+    const fastDispatch = dispatches.value.list.find(
+      (d) => d.destination === "FAST",
+    );
+    const slowDispatch = dispatches.value.list.find(
+      (d) => d.destination === "SLOW",
+    );
+    assert(fastDispatch);
+    assert(slowDispatch);
+
+    expect(queue.sentMessages).toHaveLength(2);
+    expect(fastPathPayloads).toEqual([
+      [
+        {
+          dispatchId: fastDispatch.id,
+          retryDelay: { type: "constant", interval: 7 },
+        },
+      ],
+    ]);
   });
 });
 

--- a/cf-eventhub/src/core/hub/index.ts
+++ b/cf-eventhub/src/core/hub/index.ts
@@ -1,5 +1,7 @@
 import { err, ok, safeTry } from "neverthrow";
 
+import { formatException } from "../../utils/format-exception";
+import { FastPathClient } from "../fast-path";
 import type { Logger } from "../logger";
 import {
   type CreatedEvent,
@@ -16,13 +18,30 @@ import { type Config, findRoutes } from "./routing";
 
 const constVoid = (() => {})();
 
+export type FastPathOptions = {
+  url: string;
+  secret: string;
+  waitUntil?: (promise: Promise<unknown>) => void;
+};
+
 export class EventSink {
+  private fastPath: FastPathClient | undefined;
+
   constructor(
     private repo: Repository,
     private queue: Queue,
     private routeConfig: Config,
     private logger: Logger,
-  ) {}
+    private fastPathOptions?: FastPathOptions,
+  ) {
+    if (fastPathOptions) {
+      this.fastPath = new FastPathClient(
+        fastPathOptions.url,
+        fastPathOptions.secret,
+        logger,
+      );
+    }
+  }
 
   async putEvent(events: EventPayload[]): Promise<void> {
     // Skip empty.
@@ -33,6 +52,7 @@ export class EventSink {
     const queue = this.queue;
     const repo = this.repo;
     const logger = this.logger;
+    const fastPathMessages: QueueMessage[] = [];
 
     const result = await repo.mutate(async (tx) =>
       safeTry(async function* () {
@@ -98,6 +118,11 @@ export class EventSink {
               delaySeconds: d.delaySeconds || undefined, // first delay
             }),
           );
+          fastPathMessages.push(
+            ...messages
+              .filter((m) => !m.delaySeconds)
+              .map((m): QueueMessage => m.body),
+          );
           yield* enqueue(queue, messages, logger);
         } else {
           logger.info("no dispatches created");
@@ -109,6 +134,21 @@ export class EventSink {
     if (result.isErr()) {
       return Promise.reject(result.error);
     }
+    await this.dispatchFastPath(fastPathMessages);
+  }
+
+  private dispatchFastPath(messages: QueueMessage[]) {
+    if (!this.fastPath || messages.length === 0) {
+      return;
+    }
+    const promise = this.fastPath.dispatch(messages).catch((e) => {
+      this.logger.error("fast path rejected", { error: formatException(e) });
+    });
+    if (this.fastPathOptions?.waitUntil) {
+      this.fastPathOptions.waitUntil(promise);
+      return;
+    }
+    return promise;
   }
 
   async listDispatches(args?: {
@@ -174,6 +214,7 @@ export class EventSink {
     const queue = this.queue;
     const repo = this.repo;
     const logger = this.logger;
+    const fastPathMessages: QueueMessage[] = [];
 
     const result = await repo.mutate(async (tx) =>
       safeTry(async function* () {
@@ -209,6 +250,9 @@ export class EventSink {
           contentType: "v8",
           delaySeconds: created.delaySeconds || undefined, // first delay
         };
+        if (!message.delaySeconds) {
+          fastPathMessages.push(message.body);
+        }
 
         yield* await enqueue(queue, [message], logger);
         return ok(constVoid);
@@ -218,6 +262,7 @@ export class EventSink {
     if (result.isErr()) {
       return Promise.reject(result.error);
     }
+    await this.dispatchFastPath(fastPathMessages);
   }
 
   private async markDispatchLost(args: {

--- a/cf-eventhub/src/core/index.ts
+++ b/cf-eventhub/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from "./logger";
 export * from "./executor";
+export * from "./fast-path";
 export * from "./hub";
 export * from "./hub/routing";
 export * from "./repository";

--- a/cf-eventhub/src/eventhub.ts
+++ b/cf-eventhub/src/eventhub.ts
@@ -2,6 +2,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import * as v from "valibot";
 
 import type { Handler } from "./core/executor/handler";
+import { FAST_PATH_PATH } from "./core/fast-path";
 import { EventSink } from "./core/hub";
 import { Config, type ConfigInput } from "./core/hub/routing";
 import { DefaultLogger, type LogLevel, type Logger } from "./core/logger";
@@ -14,6 +15,8 @@ export type RpcEnv = Record<string, unknown> & {
   EVENTHUB_ROUTING: string | ConfigInput;
   EVENTHUB_LOG_LEVEL?: string;
   EVENTHUB_LOST_DETECTION_ELAPSED_SECONDS?: string;
+  EVENTHUB_FAST_PATH_URL?: string;
+  EVENTHUB_FAST_PATH_SECRET?: string;
 };
 
 const getQueue = (env: RpcEnv) => {
@@ -55,6 +58,22 @@ const getLostDetectionElapsedSeconds = (env: RpcEnv) => {
 const getLogLevel = (env: RpcEnv) =>
   (env.EVENTHUB_LOG_LEVEL as LogLevel) || "INFO";
 
+const getFastPathOptions = (env: RpcEnv, ctx: ExecutionContext) => {
+  if (!env.EVENTHUB_FAST_PATH_URL && !env.EVENTHUB_FAST_PATH_SECRET) {
+    return undefined;
+  }
+  if (!env.EVENTHUB_FAST_PATH_URL || !env.EVENTHUB_FAST_PATH_SECRET) {
+    throw new Error(
+      "cf-eventhub: both EVENTHUB_FAST_PATH_URL and EVENTHUB_FAST_PATH_SECRET must be set",
+    );
+  }
+  return {
+    url: new URL(FAST_PATH_PATH, env.EVENTHUB_FAST_PATH_URL).toString(),
+    secret: env.EVENTHUB_FAST_PATH_SECRET,
+    waitUntil: ctx.waitUntil.bind(ctx),
+  };
+};
+
 export abstract class RpcEventHub<Env extends RpcEnv = RpcEnv>
   extends WorkerEntrypoint<Env>
   implements Handler
@@ -66,7 +85,13 @@ export abstract class RpcEventHub<Env extends RpcEnv = RpcEnv>
     super(ctx, env);
     const logger = this.getLogger();
     const repo = this.getRepository(logger);
-    this.sink = new EventSink(repo, getQueue(env), getRouteConfig(env), logger);
+    this.sink = new EventSink(
+      repo,
+      getQueue(env),
+      getRouteConfig(env),
+      logger,
+      getFastPathOptions(env, ctx),
+    );
     this.lostDetectionElapsedSeconds = getLostDetectionElapsedSeconds(env);
   }
 

--- a/cf-eventhub/src/executor.ts
+++ b/cf-eventhub/src/executor.ts
@@ -30,21 +30,19 @@ export abstract class RpcExecutor<
 
   private async dispatch(msg: Message<QueueMessage>) {
     const logger = this.getLogger();
-    const postponedDelaySeconds =
-      await this.dispatcher.getPostponedRetryDelaySeconds(
-        msg.body,
-        msg.attempts,
-      );
-    if (postponedDelaySeconds) {
-      msg.retry({ delaySeconds: postponedDelaySeconds });
+    const attempt = await this.dispatcher.attemptDispatch(
+      msg.body,
+      msg.attempts,
+    );
+    if (attempt.type === "postponed") {
+      msg.retry({ delaySeconds: attempt.delaySeconds });
       return;
     }
     const nextDelaySeconds = nextDelay({
       retryDelay: msg.body.retryDelay,
       attempts: msg.attempts,
     });
-    return this.dispatcher
-      .dispatch(msg.body)
+    return Promise.resolve(attempt.result)
       .then((result) => {
         switch (result) {
           case "complete":
@@ -88,26 +86,30 @@ export abstract class RpcExecutor<
       return new Response(null, { status: 404 });
     }
 
-    const payload = await parseFastPathRequest(request, secret);
+    const payload = await parseFastPathRequest(request, secret).catch((e) => {
+      this.getLogger().error("failed to parse fast path request", {
+        error: formatException(e),
+      });
+      return null;
+    });
     if (!payload) {
       return new Response(null, { status: 401 });
     }
 
     const results = [];
     for (const msg of payload.dispatches) {
-      const postponedDelaySeconds =
-        await this.dispatcher.getPostponedRetryDelaySeconds(msg);
-      if (postponedDelaySeconds) {
+      const attempt = await this.dispatcher.attemptDispatch(msg);
+      if (attempt.type === "postponed") {
         results.push({
           dispatchId: msg.dispatchId,
           result: "postponed",
-          delaySeconds: postponedDelaySeconds,
+          delaySeconds: attempt.delaySeconds,
         });
         continue;
       }
       results.push({
         dispatchId: msg.dispatchId,
-        result: await this.dispatcher.dispatch(msg),
+        result: attempt.result,
       });
     }
 

--- a/cf-eventhub/src/executor.ts
+++ b/cf-eventhub/src/executor.ts
@@ -2,6 +2,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 
 import { Dispatcher } from "./core/executor";
 import type { Handler } from "./core/executor/handler";
+import { FAST_PATH_PATH, parseFastPathRequest } from "./core/fast-path";
 import { DefaultLogger, type LogLevel, type Logger } from "./core/logger";
 import type { Repository } from "./core/repository";
 import { nextDelay } from "./core/retry-delay";
@@ -10,6 +11,11 @@ import { formatException } from "./utils/format-exception";
 
 const getLogLevel = (env: Record<string, unknown>) =>
   (env.EVENTHUB_LOG_LEVEL as LogLevel) || "INFO";
+
+const getFastPathSecret = (env: Record<string, unknown>) => {
+  const secret = env.EVENTHUB_FAST_PATH_SECRET;
+  return typeof secret === "string" && secret.length > 0 ? secret : undefined;
+};
 
 export abstract class RpcExecutor<
   Env extends Record<string, unknown> = Record<string, unknown>,
@@ -24,6 +30,15 @@ export abstract class RpcExecutor<
 
   private async dispatch(msg: Message<QueueMessage>) {
     const logger = this.getLogger();
+    const postponedDelaySeconds =
+      await this.dispatcher.getPostponedRetryDelaySeconds(
+        msg.body,
+        msg.attempts,
+      );
+    if (postponedDelaySeconds) {
+      msg.retry({ delaySeconds: postponedDelaySeconds });
+      return;
+    }
     const nextDelaySeconds = nextDelay({
       retryDelay: msg.body.retryDelay,
       attempts: msg.attempts,
@@ -60,6 +75,43 @@ export abstract class RpcExecutor<
     for (const msg of batch.messages) {
       await this.dispatch(msg);
     }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== FAST_PATH_PATH) {
+      return new Response(null, { status: 404 });
+    }
+
+    const secret = getFastPathSecret(this.env);
+    if (!secret) {
+      return new Response(null, { status: 404 });
+    }
+
+    const payload = await parseFastPathRequest(request, secret);
+    if (!payload) {
+      return new Response(null, { status: 401 });
+    }
+
+    const results = [];
+    for (const msg of payload.dispatches) {
+      const postponedDelaySeconds =
+        await this.dispatcher.getPostponedRetryDelaySeconds(msg);
+      if (postponedDelaySeconds) {
+        results.push({
+          dispatchId: msg.dispatchId,
+          result: "postponed",
+          delaySeconds: postponedDelaySeconds,
+        });
+        continue;
+      }
+      results.push({
+        dispatchId: msg.dispatchId,
+        result: await this.dispatcher.dispatch(msg),
+      });
+    }
+
+    return Response.json({ results });
   }
 
   protected getLogger() {


### PR DESCRIPTION
Set `EVENTHUB_FAST_PATH_URL` and `EVENTHUB_FAST_PATH_SECRET` on both eventhub and executor workers to start zero-delay dispatches via signed HTTP before the Queue consumer receives them. Queue messages are still enqueued as fallback.

- The eventhub sends `POST /__cf_eventhub/fast-path` with an HMAC-SHA256
  signature.
- The executor verifies the signature and calls the same dispatcher used by the
  Queue consumer.
- Only dispatches with `delaySeconds: 0` use the fast path.
- If the fast path fails, the Queue message is retried using the configured
  retry delay.